### PR TITLE
fix: set body min-height and align with flex

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,9 +22,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' className={inter.className}>
       <ThemeRegistry options={{ key: 'mui' }}>
-        <body>
+        <body className='min-h-screen flex flex-col justify-between'>
           <NavBar />
-          <main className={'mx-auto my-44 max-w-7xl'}>{children}</main>
+          <main className='my-44 max-w-7xl w-full grow self-center'>{children}</main>
           <Footer />
         </body>
       </ThemeRegistry>


### PR DESCRIPTION
set a body min-height so that the footer is always at the bottom of the page. Also use flexbox to align items instead of margins

before:

![bilde](https://github.com/openearthplatforminitiative/developer-portal/assets/22095727/96c22990-e18c-4d34-8f64-e5dfa58e7970)

after:

![bilde](https://github.com/openearthplatforminitiative/developer-portal/assets/22095727/8cffbfde-776b-4876-893f-095f0581a6b1)

