### PR TITLE
Fix/use content

### DIFF
--- a/app/code-examples/crop-health-binary.py
+++ b/app/code-examples/crop-health-binary.py
@@ -1,11 +1,15 @@
 from httpx import Client
 
+# Open the image file as a binary file
+with open("cocoa.jpg", "rb") as image_file:
+    image_bytes = image_file.read()
+
 with Client() as client:
     # Get the binary model prediction for image cocoa.jpg 
     # passed as a binary file in the request body
     response_binary = client.post(
         url="https://api-test.openepi.io/crop-health/predictions/binary",
-        content=open("cocoa.jpg", "rb").read(),
+        content=image_bytes,
     )
 
     data_binary = response_binary.json()

--- a/app/code-examples/crop-health-binary.py
+++ b/app/code-examples/crop-health-binary.py
@@ -5,7 +5,7 @@ with Client() as client:
     # passed as a binary file in the request body
     response_binary = client.post(
         url="https://api-test.openepi.io/crop-health/predictions/binary",
-        data=open("cocoa.jpg", "rb").read(),
+        content=open("cocoa.jpg", "rb").read(),
     )
 
     data_binary = response_binary.json()

--- a/app/code-examples/crop-health-multi-HLT.py
+++ b/app/code-examples/crop-health-multi-HLT.py
@@ -5,7 +5,7 @@ with Client() as client:
     # passed as a binary file in the request body
     response_multi = client.post(
         url="https://api-test.openepi.io/crop-health/predictions/multi-HLT",
-        data=open("cocoa.jpg", "rb").read(),
+        content=open("cocoa.jpg", "rb").read(),
     )
 
     data_multi = response_multi.json()

--- a/app/code-examples/crop-health-multi-HLT.py
+++ b/app/code-examples/crop-health-multi-HLT.py
@@ -1,11 +1,15 @@
 from httpx import Client
 
+# Open the image file as a binary file
+with open("cocoa.jpg", "rb") as image_file:
+    image_bytes = image_file.read()
+
 with Client() as client:
     # Get the multi-HLT model prediction for image cocoa.jpg 
     # passed as a binary file in the request body
     response_multi = client.post(
         url="https://api-test.openepi.io/crop-health/predictions/multi-HLT",
-        content=open("cocoa.jpg", "rb").read(),
+        content=image_bytes,
     )
 
     data_multi = response_multi.json()

--- a/app/code-examples/crop-health-single-HLT.py
+++ b/app/code-examples/crop-health-single-HLT.py
@@ -1,11 +1,15 @@
 from httpx import Client
 
+# Open the image file as a binary file
+with open("cocoa.jpg", "rb") as image_file:
+    image_bytes = image_file.read()
+
 with Client() as client:
     # Get the single-HLT model prediction for image cocoa.jpg 
     # passed as a binary file in the request body
     response_single = client.post(
         url="https://api-test.openepi.io/crop-health/predictions/single-HLT",
-        content=open("cocoa.jpg", "rb").read(),
+        content=image_bytes,
     )
 
     data_single = response_single.json()

--- a/app/code-examples/crop-health-single-HLT.py
+++ b/app/code-examples/crop-health-single-HLT.py
@@ -5,7 +5,7 @@ with Client() as client:
     # passed as a binary file in the request body
     response_single = client.post(
         url="https://api-test.openepi.io/crop-health/predictions/single-HLT",
-        data=open("cocoa.jpg", "rb").read(),
+        content=open("cocoa.jpg", "rb").read(),
     )
 
     data_single = response_single.json()


### PR DESCRIPTION
Modifies crop health code examples. For binary data, using `content` instead of `data` is advised