### PR TITLE
fix: set width on the individual data-catalog pages

### DIFF
--- a/app/data-catalog/crop-health/page.tsx
+++ b/app/data-catalog/crop-health/page.tsx
@@ -10,7 +10,7 @@ import CodeBlockWrapper from "@/app/components/CodeBlockWrapper"
 
 const CropHealthPage = () => {
 	return (
-		<Box className="lg:max-w-7xl px-8 lg:my-44 my-20">
+		<Box className="w-full lg:max-w-7xl px-8 lg:my-44 my-20">
 			<Link
 				href="/data-catalog"
 				className="flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1"

--- a/app/data-catalog/deforestation/page.tsx
+++ b/app/data-catalog/deforestation/page.tsx
@@ -10,7 +10,7 @@ import CodeBlockWrapper from "@/app/components/CodeBlockWrapper"
 
 const DeforestationPage = () => {
 	return (
-		<Box className="lg:max-w-7xl px-8 lg:my-44 my-20">
+		<Box className="w-full lg:max-w-7xl px-8 lg:my-44 my-20">
 			<Link
 				href="/data-catalog"
 				className="flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1"

--- a/app/data-catalog/flood/page.tsx
+++ b/app/data-catalog/flood/page.tsx
@@ -10,7 +10,7 @@ import CodeBlockWrapper from "@/app/components/CodeBlockWrapper"
 
 const FloodPage = () => {
 	return (
-		<Box className="lg:max-w-7xl px-8 lg:my-44 my-20">
+		<Box className="w-full lg:max-w-7xl px-8 lg:my-44 my-20">
 			<Link
 				href="/data-catalog"
 				className="flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1"

--- a/app/data-catalog/geocoding/page.tsx
+++ b/app/data-catalog/geocoding/page.tsx
@@ -10,7 +10,7 @@ import CodeBlockWrapper from "@/app/components/CodeBlockWrapper"
 
 const GeocodingPage = () => {
 	return (
-		<Box className="lg:max-w-7xl px-8 lg:my-44 my-20">
+		<Box className="w-full lg:max-w-7xl px-8 lg:my-44 my-20">
 			<Link
 				href="/data-catalog"
 				className="flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1"

--- a/app/data-catalog/soil/page.tsx
+++ b/app/data-catalog/soil/page.tsx
@@ -10,7 +10,7 @@ import CodeBlockWrapper from "@/app/components/CodeBlockWrapper"
 
 const SoilPage = () => {
 	return (
-		<Box className="lg:max-w-7xl px-8 lg:my-44 my-20">
+		<Box className="w-full lg:max-w-7xl px-8 lg:my-44 my-20">
 			<Link
 				href="/data-catalog"
 				className="flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1"

--- a/app/data-catalog/weather/page.tsx
+++ b/app/data-catalog/weather/page.tsx
@@ -10,7 +10,7 @@ import CodeBlockWrapper from "@/app/components/CodeBlockWrapper"
 
 const WeatherPage = () => {
 	return (
-		<Box className="lg:max-w-7xl px-8 lg:my-44 my-20">
+		<Box className="w-full lg:max-w-7xl px-8 lg:my-44 my-20">
 			<Link
 				href="/data-catalog"
 				className="flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1"


### PR DESCRIPTION
Sets a width on the individual data-catalog pages, so it sets a max width when on mobile.